### PR TITLE
Persist ~/.ssh to CircleCI workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ defaults:
     root: ~/
     paths:
       - project
+      - .ssh
 
 version: 2
 


### PR DESCRIPTION
This will allow the CircleCI container to trust GitHub when pushing.