### PR TITLE
SRC-134: Expose pre-filters to the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- SRC-134: Added support for pre-filters.
+
 ## [2.6.2] - 2019-07-19
 ### Changed
 - SFX-155: Bumped fetch-ponyfill from 4.1.0 to 6.1.0.

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -184,6 +184,11 @@ export class Query {
     return this;
   }
 
+  withPreFilterExpression(preFilterExpression: string): Query {
+    this.request['pre-filter'] = preFilterExpression;
+    return this;
+  }
+
   enableWildcardSearch(): Query {
     this.request.wildcardSearchEnabled = true;
     return this;

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -15,6 +15,7 @@ export interface Request {
     restrictNavigation: RestrictNavigation;
     biasing: Biasing;
     matchStrategy: MatchStrategy;
+    'pre-filter'?: string;
 
     // configuration
     userId: string;

--- a/test/unit/core/query.ts
+++ b/test/unit/core/query.ts
@@ -55,6 +55,7 @@ suite('Query', ({ expect }) => {
         augmentBiases: true,
         biases: [{ name: 'popularity', strength: 'Strong_Decrease' }]
       })
+      .withPreFilterExpression('brand = "shiny"')
       .enableWildcardSearch()
       .disableAutocorrection()
       .allowPrunedRefinements()

--- a/test/unit/fixtures.ts
+++ b/test/unit/fixtures.ts
@@ -32,6 +32,7 @@ export let COMPLEX_REQUEST = {
     augmentBiases: true,
     biases: [{ name: 'popularity', strength: 'Strong_Decrease' }]
   },
+  'pre-filter': 'brand = "shiny"',
   disableAutocorrection: true,
   returnBinary: false
 };


### PR DESCRIPTION
Now Bridge supports the `pre-filter` string body parameter we should include this in the Javascript API Client.